### PR TITLE
 u8_arr_to_32_arr function

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,3 +1,4 @@
+use core::traits::Into;
 use core::option::OptionTrait;
 use core::traits::TryInto;
 use core::array::SpanTrait;
@@ -28,29 +29,57 @@ fn from_u32Array_to_u8Array(mut data: Span<u32>) -> Array<u8> {
     };
     result
 }
-fn from_u8Array_to_32Array_while(mut data: Span<u8>) -> (Array<u32>, u32, u32) {
-    let mut result = array![];
-    let mut overflow = 0;
 
-    while let (Option::Some(val1), Option::Some(val2), Option::Some(val3), Option::Some(val4)) = (
-        data.pop_front(),
-        data.pop_front(),
-        data.pop_front(),
-        data.pop_front(),
-    ) {
-        let mut value = (*val1).into() * 0x1000000;
-        value += (*val2).into() * 0x10000;
-        value += (*val3).into() * 0x100;
-        value += (*val4).into();
-        result.append(value);
+
+//Works well, but could be done implemented with a loop(easier for scaling to u64 u128?)
+fn u8_arr_to_32_arr(mut data: Span<u8>) -> (Array<u32>, u32, u32){
+    // This function takes a mutable slice of u8 (`data`) as input and converts it into an array of u32.
+    // It also returns two additional values:
+    //  * `last_input_word`: This stores the last partially processed word if the input data ends באמצע (in the middle) of a word.
+    //  * `last_input_num_bytes`: This stores the number of bytes from the last partially processed word.
+
+    let mut result= array![];
+    let mut last_input_word:u32=0;
+    let mut last_input_num_bytes:u32=0;
+
+    loop {
+        match (data.pop_front(),data.pop_front(),data.pop_front(),data.pop_front()) {
+            (Option::Some(val1),Option::Some(val2),Option::Some(val3),Option::Some(val4)) => {
+                let mut value = (*val1).into() * 0x1000000;
+                value = value + (*val2).into() * 0x10000;
+                value = value + (*val3).into() * 0x100;
+                value = value + (*val4).into();
+                result.append(value);     
+            },
+            (Option::None, _, _, _) =>{
+                last_input_word=0;
+                last_input_num_bytes=0;
+                break;
+             },
+            (Option::Some(val1), Option::None, _, _) =>{
+                last_input_word = (*val1).into() * 0x1000000;
+                last_input_num_bytes=1;
+                break;
+
+            },
+            (Option::Some(val1), Option::Some(val2), Option::None, _) => {
+                let mut value = (*val1).into() * 0x1000000;
+                value += (*val2).into() * 0x10000;
+                last_input_word = value;
+                last_input_num_bytes=2;
+                break;
+            },
+            (Option::Some(val1), Option::Some(val2), Option::Some(val3), Option::None) =>{
+                let mut value = (*val1).into() * 0x1000000;
+                value += (*val2).into() * 0x10000;
+                value += (*val3).into() * 0x100;
+                last_input_word = value;
+                last_input_num_bytes=3;
+                break;
+            }
+        };
     };
-
-    while let Option::Some(byte) = data.pop_front() {
-        overflow *= 256; // Multiply by 2^8 (0x100)
-        overflow += (*byte).into();
-    };
-
-    (result, overflow, overflow)
+    (result,last_input_word,last_input_num_bytes)
 }
 
 fn from_u8Array_to_32Array(mut data: Span<u8>)->(Array<u32>,u32,u32) {
@@ -89,6 +118,8 @@ fn from_u8Array_to_32Array(mut data: Span<u8>)->(Array<u32>,u32,u32) {
     (result,overflow,overflow)
 }
 
+
+
 fn main() -> () {
     let input_1 : Array<u32> = array![1]; //u32
     let input_2 = array![0, 0, 0, 1,  0,0,1]; //u8
@@ -108,19 +139,61 @@ fn expand_slice(slice: [u32;8]) -> Array<u32> {
 
 #[cfg(test)]
 mod tests {
-    use super::from_u8Array_to_32Array;
-    use super::from_u8Array_to_32Array_while;
+    use super::u8_arr_to_32_arr;
     use super::from_u32Array_to_u8Array;
 
     #[test]
-    fn test_from_u8Array_to_u32Array() {
+    fn u8_arr_to_32_arr_single_byte_overflow() {
         let input: Array<u8> = array![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let (result, overflow1, overflow2) = from_u8Array_to_32Array(input.span());
+        let (result, last_input_word, last_input_num_bytes) = u8_arr_to_32_arr(input.span());
 
         assert_eq!(result, array![0x01020304, 0x05060708]);
-        assert_eq!(overflow1, 0x09000000); // Expecting 0x09 as the MSB
+        assert_eq!(last_input_word, 0x09000000); // Expecting 0x09 as the MSB
+        assert_eq!(last_input_num_bytes, 1); // Expecting 0x09 as the MSB
+    }
+
+    #[test]
+    fn u8_arr_to_32_arr_two_bytes_overflow() {
+        let input: Array<u8> = array![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let (result, last_input_word, last_input_num_bytes) = u8_arr_to_32_arr(input.span());
+
+        assert_eq!(result, array![0x01020304, 0x05060708]);
+        assert_eq!(last_input_word, 0x090A0000); // Expecting 0x09 as the MSB
+        assert_eq!(last_input_num_bytes, 2); // Expecting 0x09 as the MSB
+    }
+
+    #[test]
+    fn u8_arr_to_32_arr_three_bytes_overflow() {
+        let input: Array<u8> = array![1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11];
+        let (result, last_input_word, last_input_num_bytes) = u8_arr_to_32_arr(input.span());
+
+        assert_eq!(result, array![0x01020304, 0x05060708]);
+        assert_eq!(last_input_word, 0x090A0B00); // Expecting 0x09 as the MSB
+        assert_eq!(last_input_num_bytes, 3); // Expecting 0x09 as the MSB
+    }
+    #[test]
+    fn test_from_u8Array_to_u32Array_python_BIG_ENDIAN() {
+        let input: Array<u8> = array![66, 145, 72, 112];
+        let (result, last_input_word, last_input_num_bytes) = u8_arr_to_32_arr(input.span());
+
+        assert_eq!(result, array![1116817520]);
+        assert_eq!(last_input_word, 0); // Expecting 0x09 as the MSB
+        assert_eq!(last_input_num_bytes, 0); // Expecting 0x09 as the MSB
+
 
     }
+    #[test]
+    fn test_from_u8Array_to_u32Array_no_overflow() {
+        let input: Array<u8> = array![1, 2, 3, 4, 5, 6, 7, 8];
+        let (result, last_input_word, last_input_num_bytes) = u8_arr_to_32_arr(input.span());
+
+        assert_eq!(result, array![0x01020304, 0x05060708]);
+        assert_eq!(last_input_word, 0); // Expecting 0x09 as the MSB
+        assert_eq!(last_input_num_bytes, 0); // Expecting 0x09 as the MSB
+
+    }
+
+
 
     #[test]
     fn test_from_u32Array_to_u8Array() {
@@ -128,16 +201,6 @@ mod tests {
         let result = from_u32Array_to_u8Array(input.span());
 
         assert_eq!(result, array![1, 2, 3, 4, 5, 6, 7, 8]);
-    }
-    
-    #[test]
-    fn test_from_u8Array_to_32Array_while() {
-        let input: Array<u8> = array![1, 2, 3, 4, 5, 6, 7, 8, 9];
-        let (result, overflow1, overflow2) = from_u8Array_to_32Array_while(input.span());
-
-        assert_eq!(result, array![0x01020304, 0x05060708]);
-        assert_eq!(overflow1, 0x09000000); // Expecting 0x09 as the MSB
-
     }
 
 }

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -82,44 +82,6 @@ fn u8_arr_to_32_arr(mut data: Span<u8>) -> (Array<u32>, u32, u32){
     (result,last_input_word,last_input_num_bytes)
 }
 
-fn from_u8Array_to_32Array(mut data: Span<u8>)->(Array<u32>,u32,u32) {
-    let mut result= array![];
-    let mut overflow:u32=0;
-    loop {
-        match (data.pop_front(),data.pop_front(),data.pop_front(),data.pop_front()) {
-            (Option::Some(val1),Option::Some(val2),Option::Some(val3),Option::Some(val4)) => {
-                let mut value = (*val1).into() * 0x1000000;
-                value = value + (*val2).into() * 0x10000;
-                value = value + (*val3).into() * 0x100;
-                value = value + (*val4).into();
-                result.append(value);     
-            },
-            (Option::None, _, _, _) =>{break;},
-            (Option::Some(val1), Option::None, _, _) =>{
-                overflow = (*val1).into() * 0x1000000;
-                break;
-
-            },
-            (Option::Some(val1), Option::Some(val2), Option::None, _) => {
-                let mut value = (*val1).into() * 0x1000000;
-                value += (*val2).into() * 0x10000;
-                overflow = value;
-                break;
-            },
-            (Option::Some(val1), Option::Some(val2), Option::Some(val3), Option::None) =>{
-                let mut value = (*val1).into() * 0x1000000;
-                value += (*val2).into() * 0x10000;
-                value += (*val3).into() * 0x100;
-                overflow = value;
-                break;
-            }
-        };
-    };
-    (result,overflow,overflow)
-}
-
-
-
 fn main() -> () {
     let input_1 : Array<u32> = array![1]; //u32
     let input_2 = array![0, 0, 0, 1,  0,0,1]; //u8

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -1,3 +1,6 @@
+use core::option::OptionTrait;
+use core::traits::TryInto;
+use core::array::SpanTrait;
 use alexandria_math::sha256::sha256 as old_sha256;
 use core::sha256::compute_sha256_u32_array;
 use core::ArrayTrait;
@@ -20,14 +23,74 @@ fn from_u32Array_to_u8Array(mut data: Span<u32>) -> Array<u8> {
                 res = *val & 0xff;
                 result.append(res.try_into().unwrap());
             },
-            Option::None => { break; },
+            Option::None => { break; }
         };
     };
     result
 }
+fn from_u8Array_to_32Array_while(mut data: Span<u8>) -> (Array<u32>, u32, u32) {
+    let mut result = array![];
+    let mut overflow = 0;
+
+    while let (Option::Some(val1), Option::Some(val2), Option::Some(val3), Option::Some(val4)) = (
+        data.pop_front(),
+        data.pop_front(),
+        data.pop_front(),
+        data.pop_front(),
+    ) {
+        let mut value = (*val1).into() * 0x1000000;
+        value += (*val2).into() * 0x10000;
+        value += (*val3).into() * 0x100;
+        value += (*val4).into();
+        result.append(value);
+    };
+
+    while let Option::Some(byte) = data.pop_front() {
+        overflow *= 256; // Multiply by 2^8 (0x100)
+        overflow += (*byte).into();
+    };
+
+    (result, overflow, overflow)
+}
+
+fn from_u8Array_to_32Array(mut data: Span<u8>)->(Array<u32>,u32,u32) {
+    let mut result= array![];
+    let mut overflow:u32=0;
+    loop {
+        match (data.pop_front(),data.pop_front(),data.pop_front(),data.pop_front()) {
+            (Option::Some(val1),Option::Some(val2),Option::Some(val3),Option::Some(val4)) => {
+                let mut value = (*val1).into() * 0x1000000;
+                value = value + (*val2).into() * 0x10000;
+                value = value + (*val3).into() * 0x100;
+                value = value + (*val4).into();
+                result.append(value);     
+            },
+            (Option::None, _, _, _) =>{break;},
+            (Option::Some(val1), Option::None, _, _) =>{
+                overflow = (*val1).into() * 0x1000000;
+                break;
+
+            },
+            (Option::Some(val1), Option::Some(val2), Option::None, _) => {
+                let mut value = (*val1).into() * 0x1000000;
+                value += (*val2).into() * 0x10000;
+                overflow = value;
+                break;
+            },
+            (Option::Some(val1), Option::Some(val2), Option::Some(val3), Option::None) =>{
+                let mut value = (*val1).into() * 0x1000000;
+                value += (*val2).into() * 0x10000;
+                value += (*val3).into() * 0x100;
+                overflow = value;
+                break;
+            }
+        };
+    };
+    (result,overflow,overflow)
+}
 
 fn main() -> () {
-    let input_1 = array![1]; //u32
+    let input_1 : Array<u32> = array![1]; //u32
     let input_2 = array![0, 0, 0, 1,  0,0,1]; //u8
     let output_1 = expand_slice(compute_sha256_u32_array(input_1, 1, 3));
     let output_2 = old_sha256(input_2);
@@ -45,4 +108,36 @@ fn expand_slice(slice: [u32;8]) -> Array<u32> {
 
 #[cfg(test)]
 mod tests {
+    use super::from_u8Array_to_32Array;
+    use super::from_u8Array_to_32Array_while;
+    use super::from_u32Array_to_u8Array;
+
+    #[test]
+    fn test_from_u8Array_to_u32Array() {
+        let input: Array<u8> = array![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let (result, overflow1, overflow2) = from_u8Array_to_32Array(input.span());
+
+        assert_eq!(result, array![0x01020304, 0x05060708]);
+        assert_eq!(overflow1, 0x09000000); // Expecting 0x09 as the MSB
+
+    }
+
+    #[test]
+    fn test_from_u32Array_to_u8Array() {
+        let input: Array<u32> = array![0x01020304, 0x05060708];
+        let result = from_u32Array_to_u8Array(input.span());
+
+        assert_eq!(result, array![1, 2, 3, 4, 5, 6, 7, 8]);
+    }
+    
+    #[test]
+    fn test_from_u8Array_to_32Array_while() {
+        let input: Array<u8> = array![1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let (result, overflow1, overflow2) = from_u8Array_to_32Array_while(input.span());
+
+        assert_eq!(result, array![0x01020304, 0x05060708]);
+        assert_eq!(overflow1, 0x09000000); // Expecting 0x09 as the MSB
+
+    }
+
 }


### PR DESCRIPTION
This pull request implements the u8_arr_to_32_arr function, which converts an array of u8 bytes into an array of u32 words, following the specified behavior:

Consecutive blocks of 4 bytes are packed into the output array of u32.
-If the length of the input data is divisible by 4, the output array contains the packed u32 words, and both additional values (last_input_word and last_input_num_bytes) are set to 0.
-If the length of the input data is not divisible by 4, the remaining bytes are packed into the first u32 word, and the number of these remaining bytes is stored in last_input_num_bytes.

Unit tests have been added to cover different cases, including overflow scenarios and conversion between u8 and u32 arrays.